### PR TITLE
Populate quantities_list.R and dst_ functions

### DIFF
--- a/R/dst_bern.R
+++ b/R/dst_bern.R
@@ -1,0 +1,18 @@
+#' Bernoulli Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' bernoulli distributions.
+#'
+#' @param p
+#'
+#' @example dst_bern(0.3)
+#'
+#' @export
+dst_bern <- function(p){
+  if(p < 0 | p > 1){
+    stop('p must be within 0 and 1')
+  }
+  dst_parametric("bern",
+                 prob = p,
+                 .variable = "discrete")
+}

--- a/R/dst_binom.R
+++ b/R/dst_binom.R
@@ -1,0 +1,22 @@
+#' Binomial Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' binomial distributions.
+#'
+#' @param size number of trials
+#' @param p success probability for each trial
+#'
+#' @example dst_binom(10, 0.6)
+#'
+#' @export
+dst_binom <- function(size, p){
+  if(size < 0){
+    stop("Size must be non-negative")
+  }
+  if (p < 0 | p > 1){
+    stop('p must be within 0 and 1')
+  }
+  dst_parametric("binom",
+                 size = size, prob = p,
+                 .variable = "discrete")
+}

--- a/R/dst_cauchy.R
+++ b/R/dst_cauchy.R
@@ -1,0 +1,20 @@
+#' Cauchy Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' cauchy distributions.
+#'
+#' @param location
+#' @param scale > 0
+#'
+#' @example dst_cauchy(0, 1)
+#'
+#'@export
+dst_cauchy <- function(location, scale){
+  if (scale <= 0){
+    stop('Scale must be positive')
+  }
+  dst_parametric("cauchy",
+                 location = location,
+                 scale = scale,
+                 .variable = "continuous")
+}

--- a/R/dst_chisq.R
+++ b/R/dst_chisq.R
@@ -1,0 +1,18 @@
+#' Chi-squared Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' Chi-squared distributions.
+#'
+#' @param k degrees of freedom
+#'
+#' @example dst_chisq(3)
+#'
+#' @export
+dst_chisq <- function(k){
+  if (k < 0){
+    stop('k must be non-negative')
+  }
+  dst_parametric("chisq",
+                 df = k,
+                 .variable = "continuous")
+}

--- a/R/dst_exp.R
+++ b/R/dst_exp.R
@@ -5,7 +5,7 @@
 #'
 #' @param lambda rate
 #'
-#' @example dst(1)
+#' @example dst_exp(1)
 #'
 #' @export
 dst_exp <- function(lambda){
@@ -15,6 +15,7 @@ dst_exp <- function(lambda){
   dst_parametric("exp",
                  rate = lambda,
                  .variable = "continuous")
+
 }
 
 

--- a/R/dst_exp.R
+++ b/R/dst_exp.R
@@ -1,0 +1,21 @@
+#' Exponential Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' exponential distributions.
+#'
+#' @param lambda rate
+#'
+#' @example dst(1)
+#'
+#' @export
+dst_exp <- function(lambda){
+  if(lambda <= 0){
+    stop('lambda must be greater than 0')
+  }
+  dst_parametric("exp",
+                 rate = lambda,
+                 .variable = "continuous")
+}
+
+
+

--- a/R/dst_f.R
+++ b/R/dst_f.R
@@ -1,0 +1,23 @@
+#' F Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' F distributions.
+#'
+#' @param df1 > 0 degree of freedom
+#' @param df2 > 0 degree of freedom
+#'
+#' @example dst_f(2, 3)
+#'
+#' @export
+dst_f <- function(df1, df2){
+  if(df1 <= 0){
+    stop('df1 must be positive')
+  }
+  if(df2 <= 0){
+    stop('df2 must be positive')
+  }
+  dst_parametric("f",
+                 df1 = df1,
+                 df2 = df2,
+                 .variable = "continuous")
+}

--- a/R/dst_gamma.R
+++ b/R/dst_gamma.R
@@ -1,0 +1,26 @@
+#' Gamma Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' Gamma distributions.
+#'
+#' @param alpha shape > 0
+#' @param beta rate > 0
+#'
+#' @example dst_gamma(2, 1)
+#'
+#' @export
+dst_gamma <- function(alpha, beta){
+  if (alpha <= 0) {
+    stop("alpha must be positive.")
+  }
+  if (beta <= 0) {
+    stop("beta must be positive.")
+  }
+  dst_parametric("gamma",
+                 shape = alpha,
+                 rate = beta,
+                 .variable = "continuous")
+}
+
+
+

--- a/R/dst_geom.R
+++ b/R/dst_geom.R
@@ -1,0 +1,18 @@
+#' Geometric Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' geometric distributions.
+#'
+#' @param p probability of success in each trial. 0 < p <= 1
+#'
+#' @example dst_geom(0.4)
+#'
+#' @export
+dst_geom <- function(p){
+  if(p < 0 | p > 1){
+    stop('p must be within 0 and 1')
+  }
+  dst_parametric("geom",
+                 prob = p,
+                 .variable = "discrete")
+}

--- a/R/dst_hyper.R
+++ b/R/dst_hyper.R
@@ -1,0 +1,35 @@
+#' Hypergeometric Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' hypergeometric distributions.
+#'
+#' @param N the population size
+#' @param K the number of success states in the population
+#' @param n the number of draws
+#' @param k the number of observed successes
+#'
+#'
+#'
+#' @example dst_hyper(1, 5, 10, 3)
+#'
+#' @export
+dst_hyper <- function(k, K, N, n){
+  if (N < 0){
+    stop('N must be non-negative')
+  }
+  if (K < 0){
+    stop('K must be non-negative')
+  }
+  if (n < 0){
+    stop('n must be non-negative')
+  }
+  if (k < 0){
+    stop('k must be non-negative')
+  }
+  dst_parametric('hyper',
+                 x = k,
+                 m = K,
+                 n = N - K,
+                 k = n,
+                 .variable = "discrete")
+}

--- a/R/dst_nbinom.R
+++ b/R/dst_nbinom.R
@@ -1,0 +1,23 @@
+#' Negative binomial Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' negative binomial distributions.
+#'
+#'@param prob probabilities
+#'@param size > 0 target for number of successful trials
+#'
+#'@example dst_nbinom(0.5, 10)
+#'
+#'@export
+dst_nbinom <- function(size, prob){
+  if(prob < 0 | prob > 1){
+    stop('prob must be within 0 and 1')
+  }
+  if(size <= 0){
+    stop('size must be positive')
+  }
+  dst_parametric("nbinom",
+                 size = size,
+                 prob = prob,
+                 .variable = "discrete")
+}

--- a/R/dst_t.R
+++ b/R/dst_t.R
@@ -1,0 +1,18 @@
+#' The Student t Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' t distributions.
+#'
+#'@param df >0 degrees of freedom
+#'
+#'@example dst_t(3)
+#'
+#'@export
+dst_t <- function(df){
+  if(t <= 0){
+    stop('t must be positive')
+  }
+  dst_parametric("t",
+                 df = df,
+                 .variable = "continuous")
+}

--- a/R/dst_weibull.R
+++ b/R/dst_weibull.R
@@ -1,0 +1,23 @@
+#' Weibull Distribution
+#'
+#' Makes a distribution belonging to the family of
+#' Weibull distributions.
+#'
+#' @param lambda > 0 scale
+#' @param gamma > 0 shape
+#'
+#' @example dst_weibull(1, 1)
+#'
+#' @export
+dst_weibull <- function(lambda, gamma){
+  if(lambda <= 0){
+    stop('lambda must be positive')
+  }
+  if(gamma <= 0){
+    stop('gamma must be positive')
+  }
+  dst_parametric("weibull",
+                 shape = gamma,
+                 scale = lambda,
+                 .variable = "continuous")
+}

--- a/R/quantities_list.R
+++ b/R/quantities_list.R
@@ -230,7 +230,7 @@
   ),
   gev = rlang::exprs(
     mean = ifelse(shape >=1, Inf,
-                  ifelse(shape == 0, location + scale*gamma,
+                  ifelse(shape == 0, location - scale * digamma(1),
                          location + (scale*(gamma(1-shape) -1))/shape)),
     median = ifelse(shape != 0, location + scale*(log10(2)^(-shape)-1)/shape, location - scale*log10(log10(2))),
     variance = ifelse(shape >= 1/2, Inf,

--- a/R/quantities_list.R
+++ b/R/quantities_list.R
@@ -107,9 +107,28 @@
     kurtosis_exc = (1 - 6 * p * q)/(n * p * q),
     range = c(0, n)
   ),
+  bern = rlang::exprs(
+    mean = p,
+    median = ifelse(p < 1/2, 0, ifelse(p == 1/2, 0, 1)), # when p = 1/2, the median is ambigious in [0, 1], R returns 0
+    variance = p * (1-p),
+    skewness = ((1 - p) - p)/sqrt(p * (1-p)),
+    kurtosis_exc = (1 - 6*p*(1-p))/(p * (1-p)),
+    range = c(0, 1)
+  ),
+
+  nbinom = rlang::exprs(
+    mean = prob * size / (1 - prob),
+    #median = FILL_THIS_IN,
+    variance = prob * size/((1- prob)^2),
+    skewness = (1 + prob)/sqrt(prob * size),
+    kurtosis_exc = 6/size + ((1-prob)^2)/(prob*size),
+    range = c(0, 1), # need to double check
+    #evi = FILL_THIS_IN not sure
+  ),
+
   geom = rlang::exprs(
     mean = 1/p,
-    median = ifelse((-1)/log2(1 - p)%%1 != 0, (-1)/log2(1 - p), 'No unique integer'), # not sure
+    #median = ifelse((-1)/log2(1 - p)%%1 != 0, (-1)/log2(1 - p), 'No unique integer'), # not sure
     variance = (1 - p)/p^2,
     skewness = (2 - p)/sqrt(1 - p),
     kurtosis_exc = 6 + p^2/(1 - p),
@@ -142,24 +161,24 @@
     range = c(0, Inf)
     #evi = FILL_THIS_IN
   ),
-  laplace = rlang::exprs( # the location parameter a, the scale parameter b
-    mean = a,
-    median = a,
-    variance = 2*(b^2),
-    skewness = 0,
-    kurtosis_exc = 3,
-    range = c(0, 1)
-    #evi = FILL_THIS_IN
-  ),
-  fatigue = rlang::exprs(
-    mean = beta * (1 + (alpha^2) /2 ),
-    median = beta,
-    variance = (alpha * beta)^2 * (1 + (5*(alpha^2))/4),
-    skewness = (4 * alpha * (11*(alpha^2) + 6))/((5 * (alpha^2) + 4)^(3/2)),
-    kurtosis_exc = 3 + (6*(alpha^2)(93*(alpha^2) + 40))/(5*(alpha^2) + 4)^2,
-    range = c(0, Inf)
-    #evi = FILL_THIS_IN
-  ),
+  # laplace = rlang::exprs( # the location parameter a, the scale parameter b
+  #   mean = a,
+  #   median = a,
+  #   variance = 2*(b^2),
+  #   skewness = 0,
+  #   kurtosis_exc = 3,
+  #   range = c(0, 1)
+  #   #evi = FILL_THIS_IN
+  # ),
+  # fatigue = rlang::exprs(
+  #   mean = beta * (1 + (alpha^2) /2 ),
+  #   median = beta,
+  #   variance = (alpha * beta)^2 * (1 + (5*(alpha^2))/4),
+  #   skewness = (4 * alpha * (11*(alpha^2) + 6))/((5 * (alpha^2) + 4)^(3/2)),
+  #   kurtosis_exc = 3 + (6*(alpha^2)(93*(alpha^2) + 40))/(5*(alpha^2) + 4)^2,
+  #   range = c(0, Inf)
+  #   #evi = FILL_THIS_IN
+  # ),
   chisq = rlang::exprs(
       mean = k,
       median = k*((1 - 2/9*k)^3),
@@ -176,18 +195,66 @@
       kurtosis_exc = NaN,
       evi = 1,
       range = c(-Inf, Inf)
-  )
+  ),
+  hyper = rlang::exprs(
+       mean = n * K / N,
+       #median = FILL_THIS_IN,
+       variance = n* K/N * (N-K)/N * (N-n)/(N-1),
+       skewness = (N - 2*K)((N-1)^(1/2))(N - 2*n)/
+                    (((n*K*(N-K)(N - n))^(1/2))(N - 2)),
+       kurtosis_exc = 1/(n*K*(N - K)*(N-n)*(N-2)*(N-3)) *
+                        ((N-1)*(N^2) *(N*(N+1)-6*K(N-K) - 6*n*(N-n)) +
+                           6*n*K*(N-K)*(N-n)*(5*N-6)),
+       range = c(0, 1)
+       #evi = FILL_THIS_IN
+  ),
+  t = rlang::exprs(
+       mean = ifelse(nu > 1, 0, NaN),
+       median = 0,
+       variance = ifelse(nu > 2, nu/(nu-2), ifelse((nu > 1 & nu <= 2), Inf, NaN)),
+       skewness = ifelse(nu > 3, 0, NaN),
+       kurtosis_exc = ifelse(nu > 4, 6/(nu - 4), ifelse((nu > 2 & nu <= 4), Inf, NaN)),
+       range = c(0, 1),
+       evi = 0 # not sure
+  ),
+  f = rlang::exprs(
+    mean = ifelse(df2 > 4, df2 / (df2 - 2), NaN),
+    #median = FILL_THIS_IN,
+    variance = ifelse(df2 > 4, (2*(df2^2)(df1 + df2 -2))/(df1*((df2-2)^2)(df2-4)), NaN),
+    skewness = ifelse(df2 > 6, ((2*df1 + df2 -2)*sqrt(8*(df2-4)))/
+                        ((df2-6)*sqrt(df1 * (df1+df2-2))), NaN),
+    kurtosis_exc = ifelse(df2 > 8, 12*(df1*(5*df2 - 22)*(df1+df2-2) + (df2-4)*((df2-2)^2)/
+                            (df1*(df2-6)*(df2-8)(df1+df2-2))), NaN),
+    range = c(0, 1),
+    #evi = FILL_THIS_IN # not sure
+  ),
+  gev = rlang::exprs(
+    mean = ifelse(shape >=1, Inf,
+                  ifelse(shape == 0, location + scale*gamma,
+                         location + (scale*(gamma(1-shape) -1))/shape)),
+    median = ifelse(shape != 0, location + scale*(log10(2)^(-shape)-1)/shape, location - scale*log10(log10(2))),
+    variance = ifelse(shape >= 1/2, Inf,
+                      ifelse(shape == 0, (scale^2)*(pi^2)/6,
+                             (scale^2)*(gamma(1-2*shape)-(gamma(1-shape))^2)/shape^2)),
+    skewness = ifelse(shape == 0, 12*sqrt(6)*zeta(3)/(pi^3),
+                      ifelse(shape < 1/3,
+                             sign(shape)*(gamma(1-3*shape)-3*(gamma(1-2*shape))*(gamma(1-shape))+2*gamma(1-shape)^3)/((gamma(1-2*shape)-gamma(1-shape)^2)^(3/2)), NaN)),
+    kurtosis_exc = ifelse(shape == 0, 12/5,
+                          ifelse(shape < 1/4,
+                                 (gamma(1-4*shape)-4*gamma(1-4*shape)*gamma(1-shape) - 3*gamma(1-2*shape)^2 + 12*gamma(1-2*shape)*(gamma(1-shape)^2) - 6*gamma(1-shape)^4)/(gamma(1-2*shape)-gamma(1-shape)^2)^2, NaN)),
+    range = c(0, 1) # need to double check
+    #evi = FILL_THIS_IN not ure
 )
 
 
 
 
-  # rlang::exprs(
-  #   mean = FILL_THIS_IN,
-  #   median = FILL_THIS_IN,
-  #   variance = FILL_THIS_IN,
-  #   skewness = FILL_THIS_IN,
-  #   kurtosis_exc = FILL_THIS_IN,
-  #   range = c(FILL_THIS_IN, FILL_THIS_IN),
-  #   evi = FILL_THIS_IN
-  # )
+# rlang::exprs(
+#   mean = FILL_THIS_IN,
+#   median = FILL_THIS_IN,
+#   variance = FILL_THIS_IN,
+#   skewness = FILL_THIS_IN,
+#   kurtosis_exc = FILL_THIS_IN,
+#   range = c(FILL_THIS_IN, FILL_THIS_IN),
+#   evi = FILL_THIS_IN
+)

--- a/R/quantities_list.R
+++ b/R/quantities_list.R
@@ -101,11 +101,11 @@
     range = c(0, 1)
   ),
   binom = rlang::exprs(
-    mean = n * p,
-    variance = n * p * q,
-    skewness = (q - p)/sqrt( n * p * q),
-    kurtosis_exc = (1 - 6 * p * q)/(n * p * q),
-    range = c(0, n)
+    mean = size * p,
+    variance = size * p * (1-p),
+    skewness = ((1-p) - p)/sqrt( size * p * (1-p)),
+    kurtosis_exc = (1 - 6 * p * (1-p))/(size * p * (1-p)),
+    range = c(0, size)
   ),
   bern = rlang::exprs(
     mean = p,
@@ -209,11 +209,11 @@
        #evi = FILL_THIS_IN
   ),
   t = rlang::exprs(
-       mean = ifelse(nu > 1, 0, NaN),
+       mean = ifelse(df > 1, 0, NaN),
        median = 0,
-       variance = ifelse(nu > 2, nu/(nu-2), ifelse((nu > 1 & nu <= 2), Inf, NaN)),
-       skewness = ifelse(nu > 3, 0, NaN),
-       kurtosis_exc = ifelse(nu > 4, 6/(nu - 4), ifelse((nu > 2 & nu <= 4), Inf, NaN)),
+       variance = ifelse(df > 2, df/(df-2), ifelse((df > 1 & df <= 2), Inf, NaN)),
+       skewness = ifelse(df > 3, 0, NaN),
+       kurtosis_exc = ifelse(df > 4, 6/(df - 4), ifelse((df > 2 & df <= 4), Inf, NaN)),
        range = c(0, 1),
        evi = 0 # not sure
   ),
@@ -243,7 +243,7 @@
                           ifelse(shape < 1/4,
                                  (gamma(1-4*shape)-4*gamma(1-4*shape)*gamma(1-shape) - 3*gamma(1-2*shape)^2 + 12*gamma(1-2*shape)*(gamma(1-shape)^2) - 6*gamma(1-shape)^4)/(gamma(1-2*shape)-gamma(1-shape)^2)^2, NaN)),
     range = c(0, 1) # need to double check
-    #evi = FILL_THIS_IN not ure
+    #evi = FILL_THIS_IN not sure
 )
 
 


### PR DESCRIPTION
### Update
(A [checklist](https://github.com/vincenzocoia/distplyr/issues/16#issuecomment-955801560) was created to track the progress)   

 
I have added most of the distributions in [quantities_list.R](https://github.com/vincenzocoia/distionary/blob/Shuyi/R/quantities_list.R) and equipped with corresponding `dst_` files except:  

- `gev`: when shape = 0, the mean equals location + scale*<img src="https://render.githubusercontent.com/render/math?math=\gamma"> I am not sure how to deal with the Euler's constant <img src="https://render.githubusercontent.com/render/math?math=\gamma"> here
- `wilcox` and `signrank`: I am confused about these two distributions. What I found online is [DISTRIBUTION OF WILCOXON SIGNED RANK STATISTIC](http://www.medicine.mcgill.ca/epidemiology/hanley/c607/ch14/SignedRankDistrn_7.pdf) and [Wilcoxon {stats}](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/Wilcoxon.html).  Why are they treated as two seperate distributions in this package?

### My to-do-list: 
- Write `representation-dst_bern` and `representation-dst_gev`  
- Modify [dst_parametric.R](https://github.com/vincenzocoia/distionary/blob/Shuyi/R/dst_parametric.R) to throw an error when no such distribution exists  
- Write test cases 