### PR TITLE
Remove ellipsis dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Roxygen: list (markdown = TRUE, roclets = c ("namespace", "rd", "srr::srr_stats_
 RoxygenNote: 7.3.3
 Imports: 
     checkmate,
-    ellipsis,
     rlang,
     stats,
     vctrs

--- a/R/eval_property.R
+++ b/R/eval_property.R
@@ -71,7 +71,7 @@ eval_property <- function(distribution, entry, ...) {
     if (is.function(repres)) {
       return(repres(...))
     } else {
-      ellipsis::check_dots_empty()
+      rlang::check_dots_empty()
       return(repres)
     }
   }

--- a/R/mean.R
+++ b/R/mean.R
@@ -31,6 +31,6 @@
 #' checkmate package for most functions.
 #' @export
 mean.dst <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   eval_property(x, "mean")
 }

--- a/R/median.R
+++ b/R/median.R
@@ -18,6 +18,6 @@
 #' checkmate package for most functions.
 #' @export
 median.dst <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  rlang::check_dots_empty()
   eval_property(x, "median")
 }


### PR DESCRIPTION
Since it is deprecated and functions now live in rlang.  https://rlang.r-lib.org/news/index.html#argument-intake-1-0-0